### PR TITLE
✨Feat: 지원 사업 수집 로직 이전 마감 사업 삭제하는 기능 추가

### DIFF
--- a/api/dto/startup_dto.py
+++ b/api/dto/startup_dto.py
@@ -4,7 +4,10 @@ from pydantic import BaseModel, ConfigDict, Field
 
 # Request
 class StartupSupportSyncRequest(BaseModel):
+    # 가장 최신 불러온 공고 k-startup Key
     after_external_ref: Optional[str] = Field(default=None, alias="afterExternalRef")
+    # 마감일이 지나 삭제할 공고 k-startup Key
+    expired_external_refs: Optional[List[str]] = Field(default=None, alias="expiredExternalRefs")
     model_config = ConfigDict(populate_by_name=True)
 
 # Response

--- a/api/services/startup_fetch_service.py
+++ b/api/services/startup_fetch_service.py
@@ -157,11 +157,11 @@ async def _safe_fetch_json(client: httpx.AsyncClient, params: Dict[str, Any]) ->
     try:
         log_params = {k: v for k, v in params.items() if k != "serviceKey"}
         # 요청 관련 정보 찍기
-        logger.debug("[HTTP] GET 요청 보냄 → URL=%s, 요청 params=%s", BASE_URL, log_params)
-        r = await client.get(BASE_URL, params=params, timeout=10.0)
+        # logger.debug("[HTTP] GET 요청 보냄 → URL=%s, 요청 params=%s", BASE_URL, log_params)
+        # r = await client.get(BASE_URL, params=params, timeout=10.0)
         # 응답 관련 정보 찍기
-        logger.debug("[HTTP] 응답 받음 → page=%s, status=%s, bytes=%s",
-                     params.get("pageNo"), r.status_code, len(r.content))
+        # logger.debug("[HTTP] 응답 받음 → page=%s, status=%s, bytes=%s",
+        #              params.get("pageNo"), r.status_code, len(r.content))
 
         r.raise_for_status()
         ctype = r.headers.get("content-type", "")
@@ -211,17 +211,20 @@ def _filter_and_dedupe(items, seen):
 # ---------- 공개 함수 ----------
 async def fetch_startup_supports_async(
         *,
-        after_external_ref: str | None = None,
+        after_external_ref: str | None = None, # 가장 최신 공고 key
+        expired_external_refs: list[str] | None = None,   # 삭제할 공고 key 리스트
         num_rows: int = 10, # 한 번에 10개로
         batch_concurrency: int = 5,
         max_empty_batches: int = 2,
         sleep_between_batches: float = 0.05,
-        hard_max_pages: int = 500, # 상한선
+        hard_max_pages: int = 300, # 상한선
 ) -> List[CreateStartupResponseDTO]:
     # 색 표시를 위해 임시로 warning 사용
-    logger.warning("[START] after_external_ref=%s num_rows=%s batch_concurrency=%s hard_max_pages=%s",
-                after_external_ref, num_rows, batch_concurrency, hard_max_pages)
-
+    logger.warning(
+        "[START] after_external_ref=%s expired_external_refs=%s num_rows=%s batch_concurrency=%s hard_max_pages=%s",
+        after_external_ref, expired_external_refs, num_rows, batch_concurrency, hard_max_pages
+    )
+    
     all_items: List[Dict[str, Any]] = []
     seen: set[str] = set()
     empty_batches = 0


### PR DESCRIPTION
## 🔍 관련 이슈
<!--
- close #123
-->
close #14 

<br>

## ✅ 작업 분류
- [ ] 신규 기능
- [x] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->
1. 창업 지원 사업 수집 이전, 마감된 지원 사업 데이터를 삭제하는 로직을 추가했습니다.


<br>

## 👥 전달사항
<!--
1. User 도메인 구조를 변경하였습니다.
3. User 도메인 사용자 닉네임 필드를 username -> nickname으로 변경하였습니다.
-->

1. 변경된 창업 지원 사업 수집 API의 흐름은 다음과 같습니다.
마감 사업 삭제 -> 데이터 수집 -> DTO  변환 -> 벡터화 및 저장 

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
